### PR TITLE
[GATE 1775] User agent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
       <jersey.version>1.8</jersey.version>
       <commonsio.version>2.4</commonsio.version>
       <surefire.version>2.16</surefire.version>
+      <spring.version>5.0.2</spring.version>
     </properties>
 
     <dependencies>
@@ -85,9 +86,20 @@
         <version>${commonsio.version}</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-context</artifactId>
+        <version>${spring.version}.RELEASE</version>
+      </dependency>
     </dependencies>
 
     <build>
+      <resources>
+          <resource>
+              <directory>src/main/resources</directory>
+              <filtering>true</filtering>
+          </resource>
+      </resources>
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -123,7 +135,7 @@
               <propertyName></propertyName>
             </systemPropertyVariables>
             <!-- <includes>
-              <include>**/ConnectorTest.java</include>
+              <include>**/LogTest.java</include>
             </includes> -->
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
       <jersey.version>1.8</jersey.version>
       <commonsio.version>2.4</commonsio.version>
       <surefire.version>2.16</surefire.version>
-      <spring.version>5.0.2</spring.version>
     </properties>
 
     <dependencies>
@@ -85,11 +84,6 @@
         <artifactId>org.apache.commons.io</artifactId>
         <version>${commonsio.version}</version>
         <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-context</artifactId>
-        <version>${spring.version}.RELEASE</version>
       </dependency>
     </dependencies>
 

--- a/src/main/java/net/vivialconnect/model/VivialConnectResource.java
+++ b/src/main/java/net/vivialconnect/model/VivialConnectResource.java
@@ -37,6 +37,7 @@ import net.vivialconnect.model.error.VivialConnectException;
 import net.vivialconnect.model.format.JsonBodyBuilder;
 import net.vivialconnect.util.CryptoUtils;
 import net.vivialconnect.util.ReflectionUtils;
+import net.vivialconnect.util.ProjectProperties;
 
 public abstract class VivialConnectResource implements Serializable {
 
@@ -126,6 +127,19 @@ public abstract class VivialConnectResource implements Serializable {
             headers.put("Authorization", authoritzationHeader);
             headers.put("X-Auth-Date", requestTimestamp);
             headers.put("X-Auth-SignedHeaders", signedHeaders);
+            String appVersion = ProjectProperties.getProperty("application.version");
+            headers.put("User-Agent", "VivialConnect JavaClient " + appVersion);
+
+            Map<String, String> xUserAgent = new HashMap<String, String>();
+            xUserAgent.put("client_version", appVersion);
+            xUserAgent.put("lang", "Java");
+            xUserAgent.put("lang_version", System.getProperty("java.version"));
+            xUserAgent.put("publisher", "vivialconnect");
+            xUserAgent.put("platform", System.getProperty("os.name") + " " +
+                                       System.getProperty("os.version") + " " +
+                                       System.getProperty("os.arch"));
+            ObjectMapper mapper = new ObjectMapper();
+            headers.put("X-VivialConnect-User-Agent", mapper.writeValueAsString(xUserAgent));
 
             return request(endpoint, method, headers, queryParams, body, responseClass);
             /* return jerseyRequest(endpoint, method, headers, queryParams, body, responseClass); */
@@ -423,7 +437,7 @@ public abstract class VivialConnectResource implements Serializable {
     private static void disconnect(HttpURLConnection connection){
         if (connection != null){
             connection.disconnect();
-	}
+	   }
     }
 
 

--- a/src/main/java/net/vivialconnect/util/ProjectProperties.java
+++ b/src/main/java/net/vivialconnect/util/ProjectProperties.java
@@ -4,19 +4,17 @@ import java.util.Properties;
 import java.io.InputStream;
 import java.io.IOException;
 
-import org.springframework.core.io.ClassPathResource;
-
 public class ProjectProperties {
 
     private static Properties p = null;
 
     public static void getProperties() throws IOException {
 
-        ClassPathResource resource = new ClassPathResource("app.properties");
+        ClassLoader classLoader = ClassLoader.getSystemClassLoader();
         p = new Properties();
         InputStream inputStream = null;
         try {
-            inputStream = resource.getInputStream();
+            inputStream = classLoader.getResourceAsStream("app.properties");
             p.load(inputStream);
         } catch (IOException e) {
             System.out.println(e.getMessage());

--- a/src/main/java/net/vivialconnect/util/ProjectProperties.java
+++ b/src/main/java/net/vivialconnect/util/ProjectProperties.java
@@ -1,0 +1,34 @@
+package net.vivialconnect.util;
+
+import java.util.Properties;
+import java.io.InputStream;
+import java.io.IOException;
+
+import org.springframework.core.io.ClassPathResource;
+
+public class ProjectProperties {
+
+    private static Properties p = null;
+
+    public static void getProperties() throws IOException {
+
+        ClassPathResource resource = new ClassPathResource("app.properties");
+        p = new Properties();
+        InputStream inputStream = null;
+        try {
+            inputStream = resource.getInputStream();
+            p.load(inputStream);
+        } catch (IOException e) {
+            System.out.println(e.getMessage());
+        } finally {
+            inputStream.close();
+        }
+    }
+
+    public static String getProperty(String name) throws IOException {
+        if (p == null) {
+            getProperties();
+        }
+        return p.getProperty(name);
+    }
+}

--- a/src/main/resources/app.properties
+++ b/src/main/resources/app.properties
@@ -1,0 +1,1 @@
+application.version=${project.version}


### PR DESCRIPTION
Had to hack in a system to allow the client to check its own version, with Ricardo's help. Example HTTP headers:
```
{
Accept=application/json,
Authorization=HMAC MTK4AHJ1NB8QBEPPRAKKDJ9AK2L0Z5GBPOU:1cb6a06479bcd82b54820070992f950f52624314f6e7c87aca94641e31b337e1,
Date=Tue, 05 Dec 2017 15:55:28 GMT,
Host=api-stage-8c935d.moosetalk.net,
User-Agent=VivialConnect JavaClient 0.1.1,
X-Auth-Date=20171205T155528Z,
X-Auth-SignedHeaders=accept;date;host,
X-VivialConnect-User-Agent={"lang_version":"1.8.0_151",
                            "publisher":"vivialconnect",
                            "client_version":"0.1.1",
                            "lang":"Java",
                            "platform":"Linux 4.10.0-40-generic amd64"}
}
```